### PR TITLE
Add Lint Markdown Actions Workflow

### DIFF
--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -1,0 +1,21 @@
+name: Lint Markdown
+
+on:
+  push:
+    paths:
+      - '**.md' # Trigger only when markdown files were changed
+  pull_request:
+    paths:
+      - '**.md' # Trigger only when markdown files were changed
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DavidAnson/markdownlint-cli2-action@v13
+        with:
+          globs: |
+            README.md


### PR DESCRIPTION
Adds a GitHub Actions workflow which validates `README.md` for correctness using [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) anytime it is updated (both on push and when a PR is created/updated).
